### PR TITLE
chore: prepare README for 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USCMS/IRIS-HEP Analysis Software Training
 
-This repository gathers material related to the USCMS/IRIS-HEP Analysis Software Training, June 20-22, 2024: https://indico.cern.ch/event/1383972/.
+This repository gathers material related to the USCMS/IRIS-HEP Analysis Software Training, May 19-20, 2025: https://indico.cern.ch/event/1509580/.
 
 ## Links to external material
 
@@ -8,7 +8,7 @@ Content relevant to the specific sessions of the event is also linked on indico.
 For convenience, we list things here as well:
 
 - Intro about coffea-casa facility: [oshadura/coffea-casa-intro](https://github.com/oshadura/coffea-casa-intro)
-- columnar analysis tutorial: [jpivarski-talks/2024-06-20-uscms-princeton-tutorial](https://github.com/jpivarski-talks/2024-06-20-uscms-princeton-tutorial)
+- columnar analysis tutorial: Add link here
 - Analysis Grand Challenge: [iris-hep/analysis-grand-challenge/](https://github.com/iris-hep/analysis-grand-challenge/) and https://agc.readthedocs.io/
 
 ## Event details
@@ -19,11 +19,11 @@ This two day event plans to discuss:
 
 - Columnar analysis and uproot
 - Distributed analysis and Dask
-- [Data Visualization techniques and libraries](https://github.com/andrzejnovak/iris_hep_analysis_training_mplhep_2024)
+- Data Visualization techniques and libraries
 - Coffea columnar analysis framework
 - The Coffea-Casa analysis facility
 - Statistical tools
 
 Basic familiarity with basic shell, Python and Git will be assumed.
 
-This is an in person event held at Princeton University just after the USCMS annual meeting.
+This is an in person event held at Rice University just before the USCMS annual meeting.


### PR DESCRIPTION
Just replaces the 2024 links and names with the 2025 ones. Leaves link empty where we don't have one yet.